### PR TITLE
Fix node resolving to node_modules for a module in a shared directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,14 @@ function resolveImports(
     const current = path.relative(base, path.dirname(imported.path))
     const target = path.relative(base, resolved)
 
-    const relative = path.relative(current, target).replace(/\\/g, '/')
+    let relative = path.relative(current, target).replace(/\\/g, '/')
+
+    /**
+     * Check for a non-relative path and fix it to avoid node trying to resolve to node_modules
+     */
+    if (!(relative.startsWith('.') || relative.startsWith('/'))) {
+      relative = './' + relative
+    }
 
     lines[imported.index] = line.replace(imported.import, relative)
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,6 +50,12 @@ const tests: Record<string, Test> = {
     input: "import module from 'module'\nimport Component from '@/components'",
     output: "import module from 'module'\nimport Component from '../components'",
   },
+  ['should support wild card aliases within the same relative directory']: {
+    options: { config: { paths: { '@/*': ['./src/*'] } } },
+    path: './src/index.ts',
+    input: "import module from 'module'\nimport config from '@/config'",
+    output: "import module from 'module'\nimport config from './config'",
+  },
   ['should skip commented imports']: {
     options: { config },
     path: './src/pages/Page.ts',


### PR DESCRIPTION
If you have a tsconfig like this:

```json
{
  "rootDir": "./src",
  "baseUrl": ".",
  "paths": {
    "@/*": ["src/*"]
  }
}
```

And you have a file at `./src/index.ts` that tries to import a module from `@/config`, the resolved path becomes `config`. Node will try to load that module from node_modules. Instead, the resolved path **should be** `./config`.

This PR fixes that. I included a test case for this case as well.